### PR TITLE
Add support for updating passwords when using nLogin

### DIFF
--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly 'dev.folia:folia-api:1.19.4-R0.1-SNAPSHOT'
     compileOnly 'io.netty:netty-all:4.1.25.Final'
     compileOnly 'fr.xephi:authme:5.6.0-beta2'
-    compileOnly 'com.nickuc.login:nlogin-api:10.2'
+    compileOnly 'com.nickuc.login:nlogin-api:10.3'
     compileOnly 'me.clip:placeholderapi:2.11.1'
 }
 

--- a/bukkit/src/main/java/com/azuriom/azlink/bukkit/integrations/NLoginIntegration.java
+++ b/bukkit/src/main/java/com/azuriom/azlink/bukkit/integrations/NLoginIntegration.java
@@ -3,6 +3,7 @@ package com.azuriom.azlink.bukkit.integrations;
 import com.azuriom.azlink.bukkit.AzLinkBukkitPlugin;
 import com.azuriom.azlink.common.integrations.BaseNLogin;
 import com.nickuc.login.api.enums.TwoFactorType;
+import com.nickuc.login.api.event.bukkit.account.PasswordUpdateEvent;
 import com.nickuc.login.api.event.bukkit.auth.RegisterEvent;
 import com.nickuc.login.api.event.bukkit.twofactor.TwoFactorAddEvent;
 import org.bukkit.entity.Player;
@@ -34,6 +35,11 @@ public class NLoginIntegration extends BaseNLogin implements Listener {
         InetAddress address = socketAddress != null ? socketAddress.getAddress() : null;
 
         handleRegister(player.getUniqueId(), player.getName(), event.getPassword(), address);
+    }
+
+    @EventHandler
+    public void onPasswordUpdate(PasswordUpdateEvent event) {
+        handleUpdatePassword(event.getPlayerId(), event.getPlayerName(), event.getNewPassword());
     }
 
     public static void register(AzLinkBukkitPlugin plugin) {

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ description: The plugin to link your Azuriom website with your server.
 website: https://azuriom.com
 main: com.azuriom.azlink.bukkit.AzLinkBukkitPlugin
 api-version: 1.13
-softdepend: [PlaceholderAPI, SkinsRestorer]
+softdepend: [nLogin, PlaceholderAPI, SkinsRestorer]
 loadbefore: [AuthMe]
 folia-supported: true
 commands:

--- a/bungee/build.gradle
+++ b/bungee/build.gradle
@@ -6,7 +6,7 @@ repositories {
 dependencies {
     implementation project(':azlink-common')
     compileOnly 'net.md-5:bungeecord-api:1.16-R0.4'
-    compileOnly 'com.nickuc.login:nlogin-api:10.2'
+    compileOnly 'com.nickuc.login:nlogin-api:10.3'
 }
 
 processResources {

--- a/bungee/src/main/java/com/azuriom/azlink/bungee/integrations/NLoginIntegration.java
+++ b/bungee/src/main/java/com/azuriom/azlink/bungee/integrations/NLoginIntegration.java
@@ -3,6 +3,7 @@ package com.azuriom.azlink.bungee.integrations;
 import com.azuriom.azlink.bungee.AzLinkBungeePlugin;
 import com.azuriom.azlink.common.integrations.BaseNLogin;
 import com.nickuc.login.api.enums.TwoFactorType;
+import com.nickuc.login.api.event.bungee.account.PasswordUpdateEvent;
 import com.nickuc.login.api.event.bungee.auth.RegisterEvent;
 import com.nickuc.login.api.event.bungee.twofactor.TwoFactorAddEvent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -36,6 +37,11 @@ public class NLoginIntegration extends BaseNLogin implements Listener {
                 ? ((InetSocketAddress) socketAddress).getAddress() : null;
 
         handleRegister(player.getUniqueId(), player.getName(), event.getPassword(), address);
+    }
+
+    @EventHandler
+    public void onPasswordUpdate(PasswordUpdateEvent event) {
+        handleUpdatePassword(event.getPlayerId(), event.getPlayerName(), event.getNewPassword());
     }
 
     public static void register(AzLinkBungeePlugin plugin) {

--- a/bungee/src/main/resources/bungee.yml
+++ b/bungee/src/main/resources/bungee.yml
@@ -3,4 +3,4 @@ version: ${pluginVersion}
 author: Azuriom Team
 description: The plugin to link your Azuriom website with your server.
 main: com.azuriom.azlink.bungee.AzLinkBungeePlugin
-softdepend: [SkinsRestorer]
+softdepend: [nLogin, SkinsRestorer]

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compileOnly 'com.google.code.gson:gson:2.10.1'
     compileOnly 'io.netty:netty-all:4.1.42.Final'
     compileOnly 'net.skinsrestorer:skinsrestorer-api:15.0.2'
-    compileOnly 'com.nickuc.login:nlogin-api:10.2'
+    compileOnly 'com.nickuc.login:nlogin-api:10.3'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.1'

--- a/common/src/main/java/com/azuriom/azlink/common/integrations/BaseNLogin.java
+++ b/common/src/main/java/com/azuriom/azlink/common/integrations/BaseNLogin.java
@@ -37,6 +37,16 @@ public class BaseNLogin {
                 });
     }
 
+    protected void handleUpdatePassword(UUID uuid, String name, String password) {
+        this.plugin.getHttpClient()
+                .updatePassword(uuid, password)
+                .exceptionally(ex -> {
+                    this.plugin.getLogger().error("Unable to update password for " + name, ex);
+
+                    return null;
+                });
+    }
+
     protected static boolean ensureApiVersion(AzLinkPlatform platform) {
         if (nLoginAPI.getApi().getApiVersion() < 5) {
             platform.getPlugin().getLogger().warn("nLogin integration requires API v5 or higher");

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly 'com.velocitypowered:velocity-api:3.1.1'
     compileOnly 'net.elytrium.limboapi:api:1.1.13'
     compileOnly 'net.elytrium:limboauth:1.1.1'
-    compileOnly 'com.nickuc.login:nlogin-api:10.2'
+    compileOnly 'com.nickuc.login:nlogin-api:10.3'
     annotationProcessor 'com.velocitypowered:velocity-api:3.1.1'
 }
 

--- a/velocity/src/main/java/com/azuriom/azlink/velocity/AzLinkVelocityPlugin.java
+++ b/velocity/src/main/java/com/azuriom/azlink/velocity/AzLinkVelocityPlugin.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
         authors = "Azuriom Team",
         dependencies = {
                 @Dependency(id = "limboauth", optional = true),
+                @Dependency(id = "nlogin", optional = true),
                 @Dependency(id = "skinsrestorer", optional = true),
         }
 )

--- a/velocity/src/main/java/com/azuriom/azlink/velocity/integrations/NLoginIntegration.java
+++ b/velocity/src/main/java/com/azuriom/azlink/velocity/integrations/NLoginIntegration.java
@@ -4,6 +4,7 @@ import com.azuriom.azlink.common.integrations.BaseNLogin;
 import com.azuriom.azlink.velocity.AzLinkVelocityPlugin;
 import com.nickuc.login.api.enums.TwoFactorType;
 import com.nickuc.login.api.event.velocity.twofactor.TwoFactorAddEvent;
+import com.nickuc.login.api.event.velocity.account.PasswordUpdateEvent;
 import com.nickuc.login.api.event.velocity.auth.RegisterEvent;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.proxy.Player;
@@ -31,6 +32,11 @@ public class NLoginIntegration extends BaseNLogin {
         InetAddress address = player.getRemoteAddress().getAddress();
 
         handleRegister(player.getUniqueId(), player.getUsername(), event.getPassword(), address);
+    }
+
+    @Subscribe
+    public void onPasswordUpdate(PasswordUpdateEvent event) {
+        handleUpdatePassword(event.getPlayerId(), event.getPlayerName(), event.getNewPassword());
     }
 
     public static void register(AzLinkVelocityPlugin plugin) {


### PR DESCRIPTION
This PR:
- [Adds support for updating passwords](https://github.com/Azuriom/AzLink/commit/8a0177916b5ae24256e6b760f6e260b6fd05afc8) by implementing **PasswordUpdateEvent**.
- [Fixes nLoginNotLoadedException](https://github.com/Azuriom/AzLink/commit/ee21c1aa006c388aae2782a304fe82190f8e4f35) when the API is called while nLogin is not fully loaded.